### PR TITLE
Falling tetrominoes on multi-line score

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -244,6 +244,7 @@ document.addEventListener('DOMContentLoaded', () => {
         lines += 1
         scoreDisplay.innerHTML = score
         linesDisplay.innerHTML = lines
+        undraw()
         row.forEach(index => {
           squares[index].style.backgroundImage = 'none'
           squares[index].classList.remove('block2') || squares[index].classList.remove('block')
@@ -253,6 +254,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const squaresRemoved = squares.splice(currentIndex, width)
         squares = squaresRemoved.concat(squares)
         squares.forEach(cell => grid.appendChild(cell))
+        draw()
       }
     }
   }


### PR DESCRIPTION
Fixes the bug where a falling tetromino would appear elongated when you score more than one line at a time